### PR TITLE
code polish for configure script. Fix make_cluster.sh up so that it s…

### DIFF
--- a/cluster.cf.template
+++ b/cluster.cf.template
@@ -320,7 +320,7 @@ Resources:
             #!/bin/bash
             set -o xtrace
             apt-get update
-            adduser --disabled-password --gecos "" ${username}
+            adduser --disabled-password --gecos '' ${username}
             usermod -aG sudo ${username}
             cp -R /home/ubuntu/.ssh/ /home/${username}/
             chown -R ${username}:${username} /home/${username}/.ssh/
@@ -408,6 +408,7 @@ Resources:
         Fn::Base64:
           Fn::Sub: |
             #!/bin/bash
+
             set -o xtrace
 
             apt-get install -y python-setuptools
@@ -420,7 +421,7 @@ Resources:
               --verbose \
               --stack '${AWS::StackName}' \
               --region '${AWS::Region}' \
-              --resource LaunchConfig \
+              --resource LaunchConfig
 
             /usr/local/bin/cfn-signal \
               --exit-code $? \
@@ -428,7 +429,7 @@ Resources:
               --region '${AWS::Region}' \
               --resource K8sNodeGroup
 
-            adduser --disabled-password --gecos "" ${username}
+            adduser --disabled-password --gecos '' ${username}
             usermod -aG sudo ${username}
             cp -R /home/ubuntu/.ssh/ /home/${username}/
             chown -R ${username}:${username} /home/${username}/.ssh/

--- a/configure
+++ b/configure
@@ -127,18 +127,15 @@ if ! jq -c "." <<< "$AWS_INSTANCES" > /dev/null 2>&1; then
   exit 12
 fi
 
-if [[ $(num_instances) != 2 ]]; then
-  echo >&2 "AWS query returned unexpected # of instances. Expected 2 but got $(num_instances)"
-  exit 13
-fi
-
 # build machine-setup data
 # shellcheck disable=SC2089
 MACHINES='{"items":[]}'
 
-for node_type in worker master; do
-  for node in $(get_node $node_type); do
-    NAME="$(generate_name ssh-controlplane)"
+for node_tuple in worker:node master:ssh-controlplane; do
+  IFS=':' read -r node_type NODE_NAME <<< "$node_tuple"
+
+  for node in $(get_node "$node_type"); do
+    NAME="$(generate_name "$NODE_NAME")"
     NODE_ITEM=$(jq --arg name "$NAME"     '.metadata.name=$name' <<< "$NODE"                    |
                 jq --arg node "$node"     '.spec.providerConfig.value.sshConfig.host=$node'     |
                 jq --arg user "$SSH_USER" '.spec.providerConfig.value.sshConfig.username=$user' |
@@ -149,8 +146,8 @@ for node_type in worker master; do
 done
 
 # output the machine-setup ConfigMap
-for item in $(jq -c ".items[]" <<< ${MACHINES}); do
+for item in $(jq -c ".items[]" <<< "$MACHINES"); do
     echo '---'
-    yq.v2 r - <<< ${item}
+    yq.v2 r - <<< "$item"
 done
 

--- a/configure
+++ b/configure
@@ -9,112 +9,143 @@
 #          a worker node that will be used to run user workloads.
 #
 
-usage() {
-    echo "Usage:"
-    echo "  $0"
-    echo
-    echo "You must set the environment variables:"
-    echo "  AWS_ACCESS_KEY_ID – AWS access key."
-    echo "  AWS_SECRET_ACCESS_KEY – AWS secret key."
-    echo "  AWS_DEFAULT_REGION – AWS region."
-    echo "  CMS_ID – CMS Resource ID"
-    echo "  SSH_USER – ssh username"
-}
-
-check_or_die() {
-    if [[ -z "${!1}" ]]; then
-        echo "Error: $1 is not set"
-        usage
-        exit 1
-    fi
-}
-
-generate_name() {
-    # This is required on OSX. Otherwise the tr command will complain:
-    # > tr: Illegal byte sequence
-    export LC_CTYPE=C
-
-    S1=$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c9 | xargs printf "%s")
-    S2=$(cat /dev/urandom | tr -dc 'a-z0-9' | head -c5 | xargs printf "%s")
-    echo -n "$1-$S1-$S2"
-}
-
-NODE='
-{
-  "apiVersion": "cluster.k8s.io/v1alpha1",
-  "kind": "Machine",
-  "metadata": {
-    "generateName": null
-  },
-  "spec": {
-    "providerConfig": {
-      "value": {
-        "apiVersion": "sshproviderconfig/v1alpha1",
-        "kind": "SSHMachineProviderConfig",
-        "roles": null,
-        "sshConfig": {
-          "username": "ubuntu",
-          "host": null,
-          "port": 22,
-          "secretName": "cluster-private-key"
+NODE='{
+        "apiVersion": "cluster.k8s.io/v1alpha1",
+        "kind": "Machine",
+        "metadata": {
+          "generateName": null
+        },
+        "spec": {
+          "providerConfig": {
+            "value": {
+              "apiVersion": "sshproviderconfig/v1alpha1",
+              "kind": "SSHMachineProviderConfig",
+              "roles": null,
+              "sshConfig": {
+                "username": "ubuntu",
+                "host": null,
+                "port": 22,
+                "secretName": "cluster-private-key"
+              }
+            }
+          },
+          "versions": {
+            "kubelet": "1.10.6",
+            "controlPlane": "1.10.6"
+          }
         }
-      }
-    },
-    "versions": {
-      "kubelet": "1.10.6",
-      "controlPlane": "1.10.6"
-    }
-  }
+      }'
+
+usage()
+{
+    echo """
+    Usage: $0
+
+    You must set the environment variables:
+
+    AWS_ACCESS_KEY_ID     – AWS access key.
+    AWS_SECRET_ACCESS_KEY – AWS secret key.
+    AWS_DEFAULT_REGION    – AWS region.
+    CMS_ID                – CMS Resource ID
+    SSH_USER              – ssh username
+
+    """
 }
-'
 
+check_or_die()
+{
+  if [[ -z "$(command -v yq.v2)" ]]; then
+      echo >&2 "Please install yq.v2, (IE run 'go get gopkg.in/mikefarah/yq.v2')."
+      return 55
+  fi
 
-# check requirements
-if [[ -z "$(command -v yq.v2)" ]]; then
-    echo "Please install yq.v2, (ie go get gopkg.in/mikefarah/yq.v2)."
-    exit 1
-fi
-if [[ -z "$(command -v jq)" ]]; then
-    echo "Please install jq, (ie go get github.com/savaki/jq)."
-    exit 1
-fi
-check_or_die "AWS_ACCESS_KEY_ID"
-check_or_die "AWS_SECRET_ACCESS_KEY"
-check_or_die "AWS_DEFAULT_REGION"
-check_or_die "CMS_ID"
-check_or_die "SSH_USER"
+  if [[ -z "$(command -v jq)" ]]; then
+      echo >&2 "Please install jq, (IE run 'go get github.com/savaki/jq')."
+      return 60
+  fi
+
+  for check_item in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+                    AWS_DEFAULT_REGION CMS_ID SSH_USER; do
+    if [[ -z "${!check_item}" ]]; then
+        echo >&2 "Error: $check_item is not set"
+        usage
+        return 70
+    fi
+  done
+}
+
+generate_name()
+{
+  # This is required on OSX. Otherwise the tr command will complain:
+  # > tr: Illegal byte sequence
+  export LC_CTYPE=C
+  STR=""
+
+  for n in 9 5;do
+    STR+="$(< /dev/urandom tr -dc 'a-z0-9' | head -c$n)-"
+  done
+  echo -n "$1-$STR" | sed 's/-$//'
+}
 
 # fetch instance data from aws
-MASTER_RESULT=$(aws ec2 describe-instances --filters "Name=tag:cms_id,Values=${CMS_ID}" "Name=tag:role,Values=master" --query 'Reservations[].Instances[].PublicIpAddress')
-WORKER_RESULT=$(aws ec2 describe-instances --filters "Name=tag:cms_id,Values=${CMS_ID}" "Name=tag:role,Values=worker" --query 'Reservations[].Instances[].PublicIpAddress')
+get_aws_instance_data()
+{
+  aws ec2 describe-instances \
+    --filters "Name=tag:cms_id,Values=${CMS_ID}" "Name=tag:role,Values=[master,worker]" \
+    --query "Reservations[].Instances[] | [*].{ipaddress: PublicIpAddress,role: Tags[?Key == 'role'].Value | [0]}"
+}
+
+get_node()
+{
+  local node_type="$1"
+
+  [[ -z "$node_type" ]] && \
+    {
+      echo >&2 "Usage: get_node <worker|master>"
+      return 50
+    }
+
+  jq --arg type "$node_type" -Mrc '.[] | select(.role == $type).ipaddress' <<< "$AWS_INSTANCES"
+}
+
+num_instances()
+{
+  jq '. | length' <<< "$AWS_INSTANCES"
+}
+
+# check requirements
+check_or_die;r=$?
+[[ $r -gt 0 ]] && exit $r
+
+# let's just call AWS one time and do the rest in memory shall we?
+AWS_INSTANCES=$(get_aws_instance_data)
 
 # check to see that we have valid json
-if ! jq -c "" <<< $MASTER_RESULT > /dev/null 2>&1 ; then
-    echo "Failure acquiring master IP address(s)"
+if ! jq -c "." <<< "$AWS_INSTANCES" > /dev/null 2>&1; then
+  echo >&2 "Failure acquiring AWS IP address(s)"
+  jq . <<< "$AWS_INSTANCES"
+  exit 12
 fi
-if ! jq -c "" <<< $WORKER_RESULT > /dev/null 2>&1 ; then
-    echo "Failure acquiring worker IP address(s)"
+
+if [[ $(num_instances) != 2 ]]; then
+  echo >&2 "AWS query returned unexpected # of instances. Expected 2 but got $(num_instances)"
+  exit 13
 fi
 
 # build machine-setup data
+# shellcheck disable=SC2089
 MACHINES='{"items":[]}'
 
-for node in $(jq ".[]" <<< $MASTER_RESULT); do
+for node_type in worker master; do
+  for node in $(get_node $node_type); do
     NAME="$(generate_name ssh-controlplane)"
-    NODE_ITEM=$(jq '.metadata.name="'${NAME}'"' <<< $NODE |
-        jq '.spec.providerConfig.value.sshConfig.host='${node} |
-        jq '.spec.providerConfig.value.sshConfig.username="'${SSH_USER}'"' |
-        jq -c '[.spec.providerConfig.value.roles=["Master","Etcd"]]')
-    MACHINES=$(jq '.items+='${NODE_ITEM} <<< $MACHINES)
-done
-for node in $(jq ".[]" <<< $WORKER_RESULT); do
-    NAME="$(generate_name ssh-node)"
-    NODE_ITEM=$(jq '.metadata.name="'${NAME}'"' <<< $NODE |
-        jq '.spec.providerConfig.value.sshConfig.host='${node} |
-        jq '.spec.providerConfig.value.sshConfig.username="'${SSH_USER}'"' |
-        jq 'del(.spec.versions.controlPlane)' |
-        jq -c '[.spec.providerConfig.value.roles=["Node"]]')
-    MACHINES=$(jq '.items+='${NODE_ITEM} <<< $MACHINES)
+    NODE_ITEM=$(jq --arg name "$NAME"     '.metadata.name=$name' <<< "$NODE"                    |
+                jq --arg node "$node"     '.spec.providerConfig.value.sshConfig.host=$node'     |
+                jq --arg user "$SSH_USER" '.spec.providerConfig.value.sshConfig.username=$user' |
+                jq -c '[.spec.providerConfig.value.roles=["Master","Etcd"]]')
+
+    MACHINES=$( jq --argjson item "$NODE_ITEM" '.items+=$item' <<< "$MACHINES")
+  done
 done
 
 # output the machine-setup ConfigMap
@@ -122,3 +153,4 @@ for item in $(jq -c ".items[]" <<< ${MACHINES}); do
     echo '---'
     yq.v2 r - <<< ${item}
 done
+

--- a/make_cluster.sh
+++ b/make_cluster.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 
+workers()
+{
+  aws ec2 describe-instances \
+    --filters "Name=tag:cms_id,Values=${CLUSTER_ID}" "Name=tag:role,Values=worker" \
+    --query 'Reservations[].Instances[].PublicIpAddress'
+}
+
+create_key_material()
+{
+  aws ec2 create-key-pair         \
+    --key-name "${CLUSTER_ID}Key" \
+    --query 'KeyMaterial'         \
+    --output text >> $KEYFILE
+}
+
 if [ -z "${CLUSTER_ID}" ]; then
-    echo "CLUSTER_ID must be set"
+    echo "CLUSTER_ID must be set. Hint: export CLUSER_ID=<cluster_id>"
     exit 1
 fi
 
@@ -15,9 +30,19 @@ INSTANCE_TYPE=${INSTANCE_TYPE:-m4.large}
 DISK_SIZE_GB=${DISK_SIZE_GB:-40}
 SSH_LOCATION=${SSH_LOCATION:-0.0.0.0/0}
 K8S_NODE_CAPACITY=${K8S_NODE_CAPACITY:-1}
+KEYFILE=${KEYFILE:-$HOME/.ssh/${CLUSTER_ID}Key.pem}
 
-KEYFILE=$(mktemp)
-aws ec2 create-key-pair --key-name "${CLUSTER_ID}Key" --query 'KeyMaterial' --output text >> ${KEYFILE}
+if ! create_key_material; then
+    echo >&2 """
+    Unable to create key material. Was it already created? If so, this can likely be ignored.
+
+    To delete the AWS key use the command:
+    aws ec2 delete-key-pair --key-name "${CLUSTER_ID}Key"
+
+    """
+else
+  chmod 600 $KEYFILE
+fi
 
 PARAMETER_OVERRIDES="CmsId=${CLUSTER_ID}"
 PARAMETER_OVERRIDES="${PARAMETER_OVERRIDES} KeyName=${CLUSTER_ID}Key"
@@ -40,13 +65,10 @@ aws cloudformation deploy --stack-name=${CLUSTER_ID} --template-file=cluster.cf.
     SSHLocation="${SSH_LOCATION}" \
     K8sNodeCapacity="${K8S_NODE_CAPACITY}" | tee ${CREATED}
 
-
 S_TIME=2
-WORKERS=$(aws ec2 describe-instances --filters "Name=tag:cms_id,Values=${CLUSTER_ID}" "Name=tag:role,Values=worker" --query 'Reservations[].Instances[].PublicIpAddress')
-while [ $(jq ". | length" <<< "${WORKERS}") -lt ${K8S_NODE_CAPACITY} ]; do
+while [ $(jq ". | length" <<< "$(workers)") -lt ${K8S_NODE_CAPACITY} ]; do
     sleep ${S_TIME}
     S_TIME=$(( $S_TIME * $S_TIME ))
-    WORKERS=$(aws ec2 describe-instances --filters "Name=tag:cms_id,Values=${CLUSTER_ID}" "Name=tag:role,Values=worker" --query 'Reservations[].Instances[].PublicIpAddress')
 done
 
 export CMS_ID=${CLUSTER_ID} SSH_USER=${CLUSTER_USERNAME}


### PR DESCRIPTION
…tores the key automatically. This was required because if something wrong happens on initial invocation after the key gets created then subsequent invocations will fail because the key exists in aws, but not locally. So you either need to remove the on aws and recreate it or just store it in the first place. Chose the latter.

function-ized a bunch of stuff in configure.  Instead of making multiple calls to AWS, now making one call and parsing through everything once and returning what we need.